### PR TITLE
Fix @result in method_missing

### DIFF
--- a/lib/ruby-promises.rb
+++ b/lib/ruby-promises.rb
@@ -45,7 +45,7 @@ class Promise < RubyPromises::CleanObject
   end
 
   def method_missing method, *args
-    result.send method, *args
+    @result.send method, *args
   end
 
   private


### PR DESCRIPTION
`result` in `method_missing` raises a SystemStackError because Ruby can't find it as variable or method. Certainly the instance variable was meant.
